### PR TITLE
helpers: experimental "face addressing" utility

### DIFF
--- a/src/noun-helpers.test.ts
+++ b/src/noun-helpers.test.ts
@@ -1,0 +1,29 @@
+import { FaceAxes, FaceMask, dwim, experimental as x } from "./noun-helpers";
+import { Atom, Noun } from "./noun";
+
+test('experimental face mask helpers', () => {
+  // simple left-right
+  expect(x.mask(['a', 'b']))
+  .toEqual({ 'a': Atom.two, 'b': Atom.three });
+
+  // auto-consed
+  expect(x.mask(['a', '', 'b']))
+  .toEqual({ 'a': Atom.two, 'b': Atom.fromInt(7) });
+
+  // must match manual consing
+  expect(x.mask(['a', '', 'b']))
+  .toEqual(x.mask(['a', [[], 'b']]))
+
+  // deep left
+  expect(x.mask([[['a', ''], ''], 'b']))
+  .toEqual({ 'a': Atom.fromInt(8), 'b': Atom.three });
+
+  // grabbing
+  const a: FaceMask = [[['a', ''], ''], 'b'];
+  const n: Noun = dwim(a);
+  const m: FaceAxes = x.mask(a);
+  expect(x.grab(m, n, 'a'))
+  .toEqual(Atom.fromCord('a'));
+  expect(x.grab(m, n, 'b'))
+  .toEqual(Atom.fromCord('b'));
+});

--- a/src/noun-helpers.ts
+++ b/src/noun-helpers.ts
@@ -1,4 +1,36 @@
 import { enjs } from "./noun-enjs";
 import { dejs } from "./noun-dejs";
+import { Atom, Noun } from "./noun";
+import bits from "./bits";
 const dwim = dejs.dwim;
-export { enjs, dejs, dwim };
+
+export type FaceMask = string | FaceMask[];
+export type FaceAxes = { [key: string]: Atom };
+const mask = ( face: FaceMask,
+               axis: Atom = Atom.one,
+               axes: FaceAxes = {}
+             ): FaceAxes => {
+  if (typeof face === 'string') {
+    if (face === '') return axes;
+    axes[face] = axis;
+    return axes;
+  } else {
+    if (face.length === 0) return axes;
+    if (face.length === 1) {
+      return mask(face[0], axis, axes);
+    } else {
+      const left = bits.lsh(Atom.zero, Atom.one, axis);
+      axes = mask(face[0], left, axes);
+      return mask(face.slice(1), left.bump(), axes);
+    }
+  }
+}
+const grab = (axes: FaceAxes, noun: Noun, face: string): Noun => {
+  return noun.at(axes[face]);
+}
+
+const experimental = {
+  mask, grab
+}
+
+export { enjs, dejs, dwim, experimental };


### PR DESCRIPTION
Introduces experimental utilities for generating axes from a faces array that structurally represents the noun it's addressing, and then grabbing parts of that noun using those faces.

Does not support nested faces. Here as an experimental helper, need to see this used in the wild to properly judge its utility/api design. In particular, we may or may not want to add another layer of function constructors.

Ultimately, it would be good if we could `myNoun.applyFaces` or whatever, and afterwards `myNoun.at('face')` or even `myNoun.at('face.etc')`. For the latter, and for nested faces in general, we would probably want to support masks with nested faces, and propagate those into the inner nouns. Could use the mask for enhanced pretty-printing, too...